### PR TITLE
add kdesurc to use sudo intead of su in KDE

### DIFF
--- a/etc/skel/.kde/share/config/kdesurc
+++ b/etc/skel/.kde/share/config/kdesurc
@@ -1,0 +1,2 @@
+[super-user-command]
+super-user-command=sudo


### PR DESCRIPTION
Fixes issue with su-to-root (for example used with zenmap) in KDE.