### PR TITLE
Fixed outdated dconf settings for Debian 9

### DIFF
--- a/etc/dconf/db/local.d/04-more-clock-and-calendar-details
+++ b/etc/dconf/db/local.d/04-more-clock-and-calendar-details
@@ -2,5 +2,5 @@
 clock-show-date=true
 clock-show-seconds=true
 
-[org/gnome/shell/calendar]
+[org/gnome/desktop/calendar]
 show-weekdate=true

--- a/etc/dconf/db/local.d/08-touchpad-config
+++ b/etc/dconf/db/local.d/08-touchpad-config
@@ -1,2 +1,4 @@
 [org/gnome/desktop/peripherals/touchpad]
+two-finger-scrolling-enabled=true
 tap-to-click=true
+natural-scroll=false

--- a/etc/dconf/db/local.d/10-interactive-power-button
+++ b/etc/dconf/db/local.d/10-interactive-power-button
@@ -1,2 +1,0 @@
-[org/gnome/settings-daemon/plugins/power]
-button-power='interactive'

--- a/etc/dconf/db/local.d/11-change-nautilus-preferences
+++ b/etc/dconf/db/local.d/11-change-nautilus-preferences
@@ -1,3 +1,3 @@
 [org/gnome/nautilus/preferences]
 executable-text-activation='ask'
-enable-delete=true
+show-delete-permanently=true


### PR DESCRIPTION
Some dconf settings moved or a not available anymore in the new version.

@ronnystandtke Should we keep "natural scrolling" enabled for all desktop environments or not?